### PR TITLE
[codex] Publish Planoma release notes

### DIFF
--- a/planoma/releases/1.0.1/en.md
+++ b/planoma/releases/1.0.1/en.md
@@ -1,0 +1,44 @@
+# What's New in Version 1.0.1
+
+## Improvements
+
+### App Review Prompt
+- Added smart app review prompt system
+- Deferred review evaluation to avoid conflicts with deep links
+- Better timing for review requests
+
+### User Interface
+- Updated button designs throughout the app
+- Refined segmented control appearance
+- Improved calendar widget display
+- Better visual consistency
+
+### Widgets
+- Enhanced WeeklyProgress widget
+- Improvements to year progress widget view
+- Better MultiChecker widget with Liquid Glass refinements
+- Fixed widget display issues
+
+### Performance
+- Optimized app size for faster downloads
+- Better resource management
+- Improved app launch time
+
+## Bug Fixes
+
+- Fixed seasonal color issues in widgets
+- Resolved widget deep link problems
+- Corrected widget display inconsistencies
+- Fixed button customization issues
+- Improved overall app stability
+
+## Technical Improvements
+
+- Better code organization
+- Reduced app bundle size
+- Optimized resource loading
+- Improved widget architecture
+
+---
+
+Thank you for your feedback and support! 🙏

--- a/planoma/releases/1.0.10/en.md
+++ b/planoma/releases/1.0.10/en.md
@@ -1,0 +1,97 @@
+# What's New in Version 1.0.10
+
+## New Features
+
+### Backup & Restore
+- Create full backups of your habits, entries, and categories in `.planoma` format
+- Restore from backup with automatic rollback on failure
+- Category creation dates are preserved during restore
+- Share backup files across devices
+
+### Reports Tab
+- New dedicated Reports tab with weekly overview
+- Redesigned statistics and insights for your habits
+- "Check Stats" button in journey cards links directly to reports
+
+### Achievements Board
+- Redesigned achievements as a game-style board with unified layout
+- Progress tracking counts unique habit definitions, not duplicates
+- Progress bar and percentage correctly capped at 100%
+
+### Heatmap Overview Widget
+- New free widget showing a 14-day heatmap for multiple habits at a glance
+- Available in medium (5 habits) and large (10 habits) sizes
+- Auto-selects your most active habits when no selection is configured
+- Tap any habit row to jump directly to its detail view
+- Supports glass/tinted widget mode on iOS 26+
+- Localized in all 9 supported languages
+
+### Coach Showcase
+- New "Meet Your Coach" view to explore all coach personalities
+- See sample messages and pick the coach that resonates with you
+- Fully localized in all 9 supported languages
+
+### Streak Freeze & Recovery
+- Streak freeze protects your streaks when you miss a day
+- Streak recovery banner helps you get back on track after a break
+- Share your streak achievements with friends
+
+### Retention Features
+- First check-in celebration overlay to reward your first step
+- Week 1 in-app journey with contextual guidance cards
+- Weekly summary to reflect on your progress
+- Re-engagement notifications bring you back when you drift
+- Streak-at-risk alerts help you maintain consistency
+
+## Improvements
+
+### Notifications
+- Granular notification settings with per-type toggles (daily reminders, streak alerts, weekly summary)
+- Provisional notifications during onboarding — no popup, just quiet reminders
+- Unified reminder time between onboarding and notification settings
+- Fixed daily reminders re-enabling after app foreground by centralizing scheduling logic
+
+### Bad Habits UX
+- Calendar no longer shows future dates as completed for bad habits
+- Habit's own icon shown instead of shield icon in list
+- Fixed overlapping streak and overflow badges on multi-target habits
+
+### iCloud Sync
+- User-friendly sync error messages instead of cryptic CloudKit error codes
+- Clear descriptions with actionable steps for each error type (network, auth, storage, schema)
+- Warning indicator in sync status when there's an active issue
+- Sync errors are now tracked on TelemetryDeck for monitoring
+- Fixed SF Symbol icons showing as text in habit comparison view
+
+### Performance & Stability
+- Removed 49 unused sound files from app bundle
+- Improved heatmap performance and eliminated code duplication
+- Fixed MetricKit build errors and gated advanced diagnostics behind opt-in setting
+- Stable user identifier for accurate analytics tracking
+- TelemetryDeck no longer initializes in debug builds to keep analytics clean
+
+### User Interface
+- Paywall close button made more visible with glass prominent style
+- Hidden "Sotto controllo" section when completed habits are collapsed
+- Fixed grey overlay stuck after onboarding when no habits exist
+- Personality system integrated into re-engagement and streak recovery messages
+
+### Localization
+- Fixed settings translations and restructured notification settings strings
+- Localized Coach Showcase view in all 9 languages
+- Fixed missing localized strings for journey cards
+
+## Bug Fixes
+
+- Fixed daily reminders ignoring user's opt-out preference on app foreground
+- Fixed HealthKit habits not syncing via iCloud
+- Fixed bad habits calendar showing future dates as completed
+- Fixed achievements progress counting duplicate entries
+- Fixed overlapping badges on multi-target habits
+- Fixed grey overlay stuck after onboarding with no habits
+- Fixed missing switch cases in personality fallback phrases
+- Fixed restore rollback on failure
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.12/en.md
+++ b/planoma/releases/1.0.12/en.md
@@ -1,0 +1,71 @@
+# What's New in Version 1.0.12
+
+## New Features
+
+### Track Specific Workout Types
+- Track individual workout activities like running, cycling, swimming, yoga, HIIT, strength training, tennis, hiking, and more
+- New interactive metric picker with glass-style grid for choosing your workout type
+- Each workout type filters Apple Health data to count only matching sessions
+
+### Notification Icons
+- Push notifications now show your habit icon as an image attachment
+- Personality coach image appears in generic notifications
+- Cached icon rendering for faster notification delivery
+
+### Interactive Calendar Navigation
+- New Safari-style bubble indicator when dragging on the calendar
+- Smoother calendar navigation experience
+
+### Redesigned Check-In History
+- New day-by-day check-in view with swipeable weekly calendar for quick date navigation
+- Tap any day in the calendar (expanded or collapsed) to browse check-in history
+- Day actions popover anchored directly to the selected calendar cell
+- Floating action button for adding check-ins
+- Full habit theming applied throughout the view
+
+### Redesigned Template Selection
+- New basket-style UI for picking habit templates during onboarding
+- Smooth animations when adding or removing templates
+- Improved template selection UX with clearer visual feedback
+
+## Improvements
+
+### Timer Habits
+- Play/pause button replaces the old check-in button for timer habits
+- Timer progress ring now correctly shows time-based overflow
+- Centralized timer progress calculation for consistency
+
+### iPad & Layout
+- Optimized layouts for iPad with better use of screen space
+- Improved color contrast and visual consistency across devices
+
+### Better Performance
+- Progress circles and habit sorting now load faster with optimized database queries
+- Annual calendar report loads completion data in a single batch query
+- Trend chart hidden when habit has no check-in data yet
+
+### Smaller App Size
+- App download size reduced by ~25 MB through optimized image assets
+
+### Under the Hood
+- Notifications now display in the foreground
+- Removed Pow dependency, replaced with lightweight sound effects
+- Widget now reloads properly after check-in from the main app
+- Introduced versioned schema management for safer future data migrations
+- Removed unused legacy code for a cleaner, lighter codebase
+
+## Bug Fixes
+
+- Fixed bad habit progress bar showing incorrect values in detail view
+- Fixed widget not updating after check-in
+- Fixed bad habit display and stat details layout issues
+- Fixed grouped habit completion animation
+- Fixed progress circle always showing empty instead of actual completion progress
+- Fixed sorting habits by "completion" not working
+- Fixed annual calendar report showing no completion data
+- Fixed potential crash when deleting check-ins from total entries view
+- Fixed at-risk streak badges clipping on compact screens
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.13/en.md
+++ b/planoma/releases/1.0.13/en.md
@@ -1,0 +1,45 @@
+# What's New in Version 1.0.13
+
+## New Features
+
+### Apple Watch Companion App
+- Track and complete your habits directly from your wrist
+- Beautiful card-based carousel with gradient backgrounds matching each habit's color
+- Progress dots for multi-target habits and streak indicator
+- Log activities and add extra check-ins for completed habits
+- Instant feedback with optimistic updates — no waiting for iPhone sync
+- Smart ordering: actionable habits surface at the top, passive ones grouped at the bottom
+- HealthKit-driven habits update automatically on the watch, without a completion button
+
+### Watch Complications
+- **Circular**: Progress ring showing completed vs total habits at a glance
+- **Rectangular (List)**: Today's progress with your top habits and completion status
+- **Rectangular (Icons)**: Habit icons with individual segmented progress rings
+- **Inline**: Quick habit count on your watch face
+
+### Seamless iPhone ↔ Watch Sync
+- All data syncs via Bluetooth — no iCloud required on the watch
+- Real-time updates when you complete habits on either device
+- Works even when iPhone is in the background
+- Notification action buttons now mirror reliably between iPhone and watch
+
+## Improvements
+
+### Habit Editing
+- Timer and HealthKit tracking are now mutually exclusive — enabling one automatically disables the other, preventing conflicting setups
+
+### Reports Screen
+- Fixed horizontal overflow on smaller devices
+- The previous-week button is now disabled when there's no earlier habit data to show
+
+### Habit Detail
+- Fixed horizontal scroll issue in the habit detail view
+
+## Bug Fixes
+
+- Fixed weekly summary notification grammar for Italian language
+- Improved HealthKit notification icon display
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.14/en.md
+++ b/planoma/releases/1.0.14/en.md
@@ -1,0 +1,34 @@
+# What's New in Version 1.0.14
+
+## New Features
+
+### Last Done Widgets
+- New Home Screen widget that shows how long it has been since you last completed a selected habit
+- Add a quick check-in directly from the widget when you want to log the habit right away
+- The widget uses your habit's icon, colors, and theme for a more personal look
+
+### Apple Watch Smart Stack
+- New Smart Stack widget for Apple Watch that highlights the habit you have not done in the longest time
+- The widget becomes more relevant only when a habit has been neglected for a while, so it stays useful without getting in the way
+- Watch widgets now use the latest synced check-in date from your iPhone
+
+## Improvements
+
+### Apple Watch — Icons & Progress
+- Habit icons now render correctly on the watch: SF Symbols and premium icons are displayed instead of a placeholder dot
+- Timer habits show a progress bar on the watch card with accumulated time vs. target (e.g. "12m / 30m")
+- HealthKit habits show a progress bar on the watch card with the current value vs. target
+
+### Apple Watch — Complications & Background Sync
+- Watch complications now update automatically in the background every ~30 minutes, even without opening the app
+- Complications show a clear "Open Planoma on your Watch" prompt when no data has been received yet, instead of appearing blank
+
+## Bug Fixes
+
+- Fixed timer and HealthKit tracking reverting to both enabled after an iCloud sync
+- Renamed the completed habits section from "Completed today" to "Completed" to better reflect habits without a daily target
+- Fixed the new Last Done widget quick check-in button state for habits with multiple daily targets
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.2/en.md
+++ b/planoma/releases/1.0.2/en.md
@@ -1,0 +1,55 @@
+# What's New in Version 1.0.2
+
+## New Features
+
+### Siri & Shortcuts Integration
+- Basic Siri intents for habit check-in
+- Voice command support for adding check-ins
+- Shortcuts app integration for automation
+- Habit summary intents for quick updates
+
+### Recurring Paywall Reminders
+- Smart reminders for premium features
+- Onboarding paywall improvements
+- Better subscription flow clarity
+- Localized trial badges and best value indicators
+
+### Extended Language Support
+- Added Simplified Chinese localization
+- Added German localization
+- Added Russian localization
+- Added Dutch localization
+- Improved translation coverage across all languages
+
+## Improvements
+
+### Subscription & Onboarding
+- Clarified subscription terms on onboarding
+- Limited trial disclaimer to annual plan
+- Improved introductory offer visibility
+- Better localization of subscription features
+- Fixed translation inconsistencies
+
+### Performance
+- Optimized timer-based cells
+- Reduced attribute cycles for better performance
+- Fixed active cells responsiveness
+- Improved cell update efficiency
+
+### Widgets
+- Fixed deep links for better navigation
+- Improved widget reliability
+- Better seasonal color handling
+- Enhanced widget display consistency
+
+## Bug Fixes
+
+- Fixed Chinese localization issues
+- Resolved translation problems
+- Corrected onboarding flow issues
+- Fixed demo assets display
+- Improved button styling consistency
+
+---
+
+Now available in 9 languages! 🌍

--- a/planoma/releases/1.0.3/en.md
+++ b/planoma/releases/1.0.3/en.md
@@ -1,0 +1,56 @@
+# What's New in Version 1.0.3
+
+## New Features
+
+### iOS 26 Compatibility
+- Full compatibility with iOS 26
+- Liquid Glass design integration for main buttons
+- Modern UI updates throughout the app
+
+### Improved Widgets
+- Enhanced WeeklyProgress widget design
+- Better MultiChecker widget with Liquid Glass support
+- Improved year progress widget view
+- Updated calendar widget
+- Fixed widget color updates to match habit themes
+
+## Improvements
+
+### User Interface
+- Refined Liquid Glass design for main buttons
+- Better segmented control customization
+- Improved calendar widget display
+- Enhanced widget readability
+
+### Performance
+- Optimized completion fetch with task modifiers
+- Optimistic handling of completions for faster UI updates
+- Better statistics update consistency across check-in sources
+- Unified HabitService architecture for better performance
+
+### Settings & Subscriptions
+- Fixed links on settings page
+- Improved subscription manager functionality
+- Added missing links on subscription view
+- Better subscription flow management
+
+## Bug Fixes
+
+- Fixed widget inheritance issues
+- Resolved widget possible errors
+- Corrected habit statistics update delays
+- Fixed theme application in widgets
+- Resolved switch statement conflicts
+- Fixed translation for add check-in button
+- Added missing emoji icons
+
+## Technical Improvements
+
+- Unified service architecture
+- Eliminated code duplication in habit services
+- Better result type handling
+- Improved service calls throughout the app
+
+---
+
+Enjoy the enhanced iOS 26 experience! 🎉

--- a/planoma/releases/1.0.5/en.md
+++ b/planoma/releases/1.0.5/en.md
@@ -1,0 +1,58 @@
+# What's New in Version 1.0.5
+
+## New Features
+
+### Widget Tutorial
+- New comprehensive widget tutorial in the app
+- Step-by-step guide to adding and customizing widgets
+- Learn how to make the most of your habit tracking widgets
+
+### Live Activities Improvements
+- Enhanced Live Activities functionality
+- Better real-time updates for ongoing habits
+- Improved reliability and performance
+
+### Extended Language Support
+- Added French localization
+- Added Spanish localization
+- Added Portuguese localization
+- Better translation coverage across the app
+
+## Improvements
+
+### Widgets & Home Screen
+- Improved widget designs with glass effects
+- Enhanced weekly widget display
+- Fixed widget deep links for better navigation
+- More polished widget animations
+- Seasonal color adjustments for widgets
+
+### User Interface
+- Glass effects throughout the app for a modern look
+- Improved cell animations with better visual feedback
+- More prominent completion indicators
+- Enhanced haptic feedback for user interactions
+- Better button designs and layouts
+
+### Onboarding Experience
+- Improved onboarding flow
+- Enhanced demo assets for better first impressions
+- Clearer guidance for new users
+
+### Performance & Reliability
+- Sync manager for better cell updates
+- Fixed background update issues when app is inactive
+- Improved sync status display in detail view
+- Better ordering and sorting of habits
+
+## Bug Fixes
+
+- Fixed deep links for widgets
+- Resolved widget display issues
+- Corrected translation inconsistencies
+- Fixed background sync problems
+- Improved app size optimization
+
+---
+
+Enjoy the enhanced experience with better widgets and multilingual support! 🌍

--- a/planoma/releases/1.0.6/en.md
+++ b/planoma/releases/1.0.6/en.md
@@ -1,0 +1,47 @@
+# What's New in Version 1.0.6
+
+## New Features
+
+### Consistency Score
+- New consistency score metric to track your habit completion patterns
+- Better insights into your habit-building progress
+- Visual feedback on how regularly you complete your habits
+
+### Enhanced Goal Celebrations
+- More icons and visual rewards when you complete habit goals
+- Improved motivational widgets to keep you engaged
+- Celebrate your achievements with beautiful animations
+
+### User Activity Management
+- More robust user activity tracking
+- Better handling of app state and session management
+- Improved reliability when switching between app and widgets
+
+## Improvements
+
+### Widgets
+- Improved motivational widget design and functionality
+- Better widget descriptions and titles
+- Added Italian and English localization for widget content
+
+### Notifications
+- Enhanced toast notification system
+- More polished notification animations and timing
+- Better visual feedback for user actions
+
+### User Interface
+- Fixed inconsistencies in Settings view
+- Improved cell components that depend on timers
+- Better visual consistency across the app
+
+## Bug Fixes
+
+- Fixed streak calculation issues
+- Corrected habit completion calculations
+- Resolved toast view display problems
+- Fixed compatibility issues with iOS 26.1
+- Improved overall app stability
+
+---
+
+Thank you for your continued support! Keep building those habits! 💪

--- a/planoma/releases/1.0.7/en.md
+++ b/planoma/releases/1.0.7/en.md
@@ -1,0 +1,65 @@
+# What's New in Version 1.0.7
+
+## New Features
+
+### AI-Powered Habit Suggestions
+- Get intelligent habit suggestions as you type habit names
+- On-device AI generates personalized suggestions with real-time streaming
+- Suggested icons, colors, and frequencies based on your input
+- Detailed explanations for why each suggestion fits your habit
+- Fully localized in all 9 supported languages
+- Privacy-focused: all processing happens on your device
+
+### Recently Deleted with 30-Day Safety Net
+- Deleted habits are now kept for 30 days before permanent removal
+- Access your recently deleted habits from Settings
+- Restore accidentally deleted habits with a single tap
+- Navigate to habit details even after deletion
+
+### Priority Levels for Better Organization
+- Set priority levels for your habits: Normal, Important, or Urgent
+- Sort and filter habits by priority to focus on what matters most
+- Beautiful new priority selector with explanations for each level
+- Visual indicators help you stay on track with your goals
+
+### In-App Changelog
+- View release notes directly in Settings → Changelog
+- Automatic "What's New" sheet appears after each update
+- Share release notes with others
+- Never miss what's new in each version
+
+## Improvements
+
+### Performance & Stability
+- Fixed critical memory leaks reducing app memory usage by 60-70%
+- Resolved multiple SwiftData crashes in Recently Deleted view
+- Improved list rendering performance for smoother scrolling
+- Fixed widget data sync issues with deleted habits
+
+### User Interface
+- Applied iOS 26 Liquid Glass design to Recently Deleted view
+- Improved button visibility and tap areas throughout the app
+- Better visual feedback for interactive elements
+- Refined habit cell layouts and animations
+
+### Localization
+- Major reorganization: split localization files into 8 category-specific files
+- Removed 534 duplicate translation keys across all languages
+- Organized all localization resources into dedicated Resources folder
+- Added missing translations for priority levels in all languages
+- Completed soft delete translations across all supported languages
+- Fixed translation issues in filter options
+- Improved maintainability for future translations
+
+## Bug Fixes
+
+- Fixed crashes when permanently deleting habits
+- Resolved navigation issues in Recently Deleted view
+- Fixed habit restoration bugs
+- Corrected menu visibility for deleted habits
+- Fixed sound manager logging issues
+- Resolved various compilation and build errors
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.8/en.md
+++ b/planoma/releases/1.0.8/en.md
@@ -1,0 +1,71 @@
+# What's New in Version 1.0.8
+
+## New Features
+
+### Frequency-Aware Statistics
+- Statistics now adapt to your habit's frequency — weekly, monthly, and custom frequency habits show period-appropriate metrics instead of daily counts
+
+### Live Activity Timer Enhancements
+- Receive a notification when your timer reaches its target duration
+- View your running timer in the Apple Watch Smart Stack
+- See a clear stopped state when your timer ends on the Lock Screen and Dynamic Island
+- Long-press a habit cell to start, stop, or resume a timer directly from the context menu
+
+### Home Screen Quick Actions
+- Long-press the app icon to quickly send feedback
+
+### Redesigned Subscription Screen
+- Clearer plan comparison with an animated feature carousel and improved selection experience
+
+### iCloud Sync Details
+- Redesigned sync status page with a dedicated data comparison view to easily check what's synced
+
+### Orphan iCloud Record Cleanup
+- Detect and remove leftover iCloud records from deleted habits to free up space
+
+## Improvements
+
+### Smarter Completion Tracking
+- Weekly, monthly, and custom frequency habits now correctly display the full period count everywhere in the app
+- Timer-based habits properly account for manual check-ins alongside timed sessions
+- Centralized completion logic ensures consistent behavior across list, calendar, and widget views
+
+### Refined Sort & Filter
+- Improved styling for sort and filter controls
+- Smooth transition animation when changing sort order
+
+### Visual Polish
+- Consistent check-in button colors between row and card layouts
+- Monthly calendar cells now update background immediately after adding a check-in
+
+### Updated Localizations
+- Refreshed translations across all supported languages
+
+## Bug Fixes
+
+- Fixed Live Activity timer visually continuing after pressing Stop
+- Fixed timer stopped from a Live Activity not saving the check-in
+- Fixed Live Activity background too transparent on the Lock Screen and Apple Watch
+- Fixed Live Activity timer on Apple Watch showing frozen progress and a cropped icon
+- Fixed Live Activity progress bar too wide on the Apple Watch Smart Stack
+- Fixed donated Siri intents from deleted habits still appearing in Shortcuts and Spotlight
+- Fixed Siri intents not donated correctly after completing a habit
+- Fixed Siri tip view overlapping the timer section
+- Fixed time-based habits incorrectly grouped as completed
+- Fixed weekly/monthly habits showing only today's count instead of the full period total in list cells
+- Fixed timer habits ignoring manual check-ins in calendar and widget views
+- Fixed custom frequency habits showing wrong completion count in list cells
+- Fixed timer-based habits ignoring frequency setting and manual backdated check-ins
+- Fixed weekly completion not tracking when a check-in was added for a past date
+- Fixed AttributeGraph cycle warning when sorting habits by priority
+- Fixed monthly calendar cell background not refreshing after a new check-in
+- Fixed Home Screen Quick Actions not triggering correctly
+
+## Under the Hood
+
+- Migrated calendar views to a standalone PlanomaUI-Calendar package for better modularity
+- Migrated HabitoDataModel to Swift 6 with SwiftData indexes for faster queries
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/1.0.9/en.md
+++ b/planoma/releases/1.0.9/en.md
@@ -1,0 +1,86 @@
+# What's New in Version 1.0.9
+
+## New Features
+
+### Achievement System
+- Unlock achievements as you build consistency — streak milestones, perfect weeks, perfect months, consistency tiers, and total completions
+- Beautiful holographic achievement cards with glitter effects, tier-specific patterns, and custom illustrations
+- Milestone celebrations with confetti, sound effects, and toast notifications when you reach a new achievement
+- Browse your full achievement gallery from Settings, with locked badges showing what's next to unlock
+
+### Apple Health Integration
+- Link habits to Apple Health data — steps, distance, calories, workout minutes, cycling, swimming, and more
+- Sports habits are automatically verified using real health data, so habits like "Walk 2 km" or "Exercise 30 min" complete themselves
+- See live progress directly in habit cells with compact metrics (e.g. "1.2k/3k steps") and a gradual ring fill
+- Background sync keeps your habits up to date even when the app is closed
+- Personalized progress notifications that match your chosen personality tone when you reach 50% and 100% of a health goal
+- Progress ring overflow for single-session HealthKit habits that exceed their target
+
+### Redesigned Habit Creation
+- New guided 3-step wizard for creating habits with a visual tracking-type carousel and live preview card
+- Quick-start templates and AI-powered name suggestions to get you started faster
+
+### Daily Progress Header
+- New progress bar in the navigation header showing how many habits you've completed today
+- At-risk streaks indicator so you never accidentally break a long streak
+
+### Group by Tracking Type
+- New display option to group your habits by tracking type (Goal, Limit, Log)
+
+### Bad Habits — Distinct Visual Language
+- Bad habits now have their own visual identity with amber warning states and shield icons in widgets
+- Dedicated sections when grouping by completion status, so limits are clearly separated from goals
+- Overflow badge shows when you've exceeded your tolerance limit for a bad habit
+
+## Improvements
+
+### Better Progress Rings
+- Segmented progress ring for habits with multiple daily targets, so you can see each completion at a glance
+- Dynamic gradient that fills proportionally to your current progress
+- Refined visual details — endpoint dots now appear only near completion
+- Overflow badge and text styling for habits that exceed their target count
+
+### Smarter iCloud Sync
+- Real CloudKit event tracking replaces simulated sync monitoring for accurate sync status
+- Sync details now show last import and last export separately
+- Transient network errors no longer show alarming error messages
+
+### Better History & Timestamps
+- Timer and HealthKit metadata now visible in all history views
+- Check-ins use actual timestamps instead of defaulting to midnight or random hours
+
+### Enhanced Stability
+- Improved how the app recovers from unexpected database issues instead of closing abruptly
+- Widgets are now more resilient to calendar edge cases across different regions and locales
+- Added memory limits to internal caches to reduce memory usage over time
+
+### Smoother Performance
+- Removed unnecessary pauses during data container setup for faster launch and sync toggling
+- Prevented brief interface freezes when saving data under certain conditions
+- Reduced memory pressure that could cause the app to restart in the background
+- Cleaned up unused widget code and fixed observer leaks for a lighter memory footprint
+
+## Bug Fixes
+
+- Fixed the app unexpectedly closing due to a background process running longer than allowed
+- Fixed widgets occasionally crashing when calculating dates near week or year boundaries
+- Fixed habits appearing as invalid in widgets after being deleted in the main app
+- Fixed habit detail view briefly showing incorrect data when switching quickly between habits
+- Fixed statistics updating multiple times during a single HealthKit sync
+- Fixed weekly and custom frequency health habits not tracking progress correctly when target count is greater than 1
+- Fixed bad habits calendar showing future dates as completed
+- Fixed overlapping streak and overflow badges on multi-target habits
+- Fixed color and icon selection circles being clipped in the customization step
+- Fixed SF Symbol icons rendering as raw text instead of images
+- Fixed stale HealthKit step count still showing after midnight
+- Fixed check-in timestamp showing 00:00 when added from the calendar for today
+- Fixed HealthKit multi-session entries also showing 00:00 timestamp
+- Fixed HealthKit multi-session habit progress showing cumulative total instead of session count
+- Fixed progress bar and at-risk indicator not working correctly for non-daily habits
+- Fixed pull-to-refresh spinner not appearing on habit lists
+- Fixed duplicate HealthKit completions for non-daily habits
+- Fixed circular progress dot not following overflow position
+
+---
+
+Thank you for using Planoma! We're constantly working to make your habit tracking experience better.

--- a/planoma/releases/manifest.json
+++ b/planoma/releases/manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "releases": [
+    { "version": "1.0.14", "releaseDate": "2026-06-18", "title": "What's New in Version 1.0.14", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.14/en.md" } },
+    { "version": "1.0.13", "releaseDate": "2026-04-13", "title": "What's New in Version 1.0.13", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.13/en.md" } },
+    { "version": "1.0.12", "releaseDate": "2026-03-25", "title": "What's New in Version 1.0.12", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.12/en.md" } },
+    { "version": "1.0.10", "releaseDate": "2026-03-16", "title": "What's New in Version 1.0.10", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.10/en.md" } },
+    { "version": "1.0.9", "releaseDate": "2026-02-23", "title": "What's New in Version 1.0.9", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.9/en.md" } },
+    { "version": "1.0.8", "releaseDate": "2026-02-11", "title": "What's New in Version 1.0.8", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.8/en.md" } },
+    { "version": "1.0.7", "releaseDate": "2026-01-27", "title": "What's New in Version 1.0.7", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.7/en.md" } },
+    { "version": "1.0.6", "releaseDate": "2025-12-27", "title": "What's New in Version 1.0.6", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.6/en.md" } },
+    { "version": "1.0.5", "releaseDate": "2025-11-27", "title": "What's New in Version 1.0.5", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.5/en.md" } },
+    { "version": "1.0.3", "releaseDate": "2025-10-27", "title": "What's New in Version 1.0.3", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.3/en.md" } },
+    { "version": "1.0.2", "releaseDate": "2025-09-27", "title": "What's New in Version 1.0.2", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.2/en.md" } },
+    { "version": "1.0.1", "releaseDate": "2025-09-27", "title": "What's New in Version 1.0.1", "revision": 1, "localizations": { "en": "https://icesco.github.io/planoma/releases/1.0.1/en.md" } }
+  ]
+}


### PR DESCRIPTION
## What changed

- publishes the Planoma release-note manifest on GitHub Pages
- adds the 12 existing English release-note documents under versioned paths
- includes per-release revisions for client cache invalidation

## Why

Planoma can load its changelog remotely instead of accumulating historical Markdown files in the application bundle.

## Validation

- parsed the manifest as JSON
- verified every manifest URL maps to a local release-note file
- checked the staged diff for whitespace errors
